### PR TITLE
Fix for rendering bugs in ConvertPolys_Hardware

### DIFF
--- a/Source/MgsLib/Psx.hpp
+++ b/Source/MgsLib/Psx.hpp
@@ -145,7 +145,7 @@ struct DRAWENV
     WORD offx;
     WORD offy;
     PSX_RECT textureWindow;
-    BYTE texturePage;
+    WORD texturePage;
     BYTE dtd;
     BYTE dfe;
     BYTE isbg;

--- a/Source/MgsLib/Renderer.cpp
+++ b/Source/MgsLib/Renderer.cpp
@@ -1956,9 +1956,8 @@ int CC ConvertPolys_Hardware(TaggedOrderingTablePointer* otItem, int otItemSize)
 
             gDrawEnv_6C0E98.texturePage = pStructVert->field0 & 0x1FF;
 
-            // Set dtd and dfe TODO: Check right way around
-            gDrawEnv_6C0E98.dtd = ((pStructVert->field0 >> 10) & 1);
-            gDrawEnv_6C0E98.dfe = ((pStructVert->field0 >> 9) & 1);
+            gDrawEnv_6C0E98.dtd = ((pStructVert->field0 >> 9) & 1);
+            gDrawEnv_6C0E98.dfe = ((pStructVert->field0 >> 10) & 1);
 
             size_dword_791C58 = 1;
             break;


### PR DESCRIPTION
- DRAWENV.texturePage was declared as BYTE instead of WORD
- DRAWENV dtd and dfe assignments were swapped in case 225